### PR TITLE
Add CI/CD pipeline and npm publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main, "fix/*", "feature/*"]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make build
+      - run: make test
+      - run: make check-network-isolation
+
+  build-all-platforms:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: make build-all-platforms
+      - uses: actions/upload-artifact@v4
+        with:
+          name: binaries
+          path: build/slack-mcp-*
+          retention-days: 7

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,67 @@
+name: Publish to npm
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: https://registry.npmjs.org
+
+      - name: Build all platforms
+        run: make build-all-platforms
+
+      - name: Copy binaries to npm packages
+        run: make npm-copy-binaries
+
+      - name: Determine version and npm tag
+        id: meta
+        run: |
+          VERSION=$(git describe --tags --always | sed 's/^v//' | cut -d- -f1)
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+
+          if echo "$VERSION" | grep -qE 'alpha|beta|rc'; then
+            TAG=$(echo "$VERSION" | grep -oE 'alpha|beta|rc')
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=latest" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set version in packages
+        run: make npm-set-version NPM_VERSION=${{ steps.meta.outputs.version }}
+
+      - name: Publish platform packages
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          for dir in npm/slack-mcp-server-*/; do
+            echo "Publishing $(basename $dir)..."
+            cd "$dir"
+            npm publish --access public --provenance --tag ${{ steps.meta.outputs.tag }}
+            cd ../..
+          done
+
+      - name: Publish wrapper package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          cp LICENSE npm/slack-mcp-server/
+          cd npm/slack-mcp-server
+          npm publish --access public --provenance --tag ${{ steps.meta.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: GitHub Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build all platforms
+        run: make build-all-platforms
+
+      - name: Generate checksums
+        run: |
+          cd build
+          sha256sum slack-mcp-* > checksums.txt
+          cat checksums.txt
+
+      - name: Create release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          gh release view "$TAG" 2>/dev/null || \
+            gh release create "$TAG" --title "$TAG" --generate-notes
+          gh release upload "$TAG" build/slack-mcp-* build/checksums.txt --clobber

--- a/Makefile
+++ b/Makefile
@@ -17,15 +17,16 @@ LD_FLAGS = -s -w \
 COMMON_BUILD_ARGS = -ldflags "$(LD_FLAGS)"
 
 NPM_VERSION = $(shell git describe --tags --always | sed 's/^v//' | cut -d- -f1)
+NPM_PKG_PREFIX = slack-mcp-server
 OSES = darwin linux windows
 ARCHS = amd64 arm64
 
 CLEAN_TARGETS :=
 CLEAN_TARGETS += '$(BINARY_NAME)'
 CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),./build/$(BINARY_NAME)-$(os)-$(arch)$(if $(findstring windows,$(os)),.exe,)))
-CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),./npm/$(BINARY_NAME)-$(os)-$(arch)/bin/))
-CLEAN_TARGETS += ./npm/slack-mcp-server/.npmrc ./npm/slack-mcp-server/LICENSE ./npm/slack-mcp-server/README.md
-CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),./npm/$(BINARY_NAME)-$(os)-$(arch)/.npmrc))
+CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),./npm/$(NPM_PKG_PREFIX)-$(os)-$(arch)/bin/))
+CLEAN_TARGETS += ./npm/$(NPM_PKG_PREFIX)/.npmrc ./npm/$(NPM_PKG_PREFIX)/LICENSE ./npm/$(NPM_PKG_PREFIX)/README.md
+CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),./npm/$(NPM_PKG_PREFIX)-$(os)-$(arch)/.npmrc))
 
 # The help will print out all targets with their descriptions organized bellow their categories. The categories are represented by `##@` and the target descriptions by `##`.
 # The awk commands is responsible to read the entire set of makefiles included in this invocation, looking for lines of the file as xyz: ## something, and then pretty-format the target and help. Then, if there's a line with ##@ something, that gets pretty-printed as a category.
@@ -58,26 +59,29 @@ build-all-platforms: clean tidy format ## Build the project for all platforms
 npm-copy-binaries: build-all-platforms ## Copy the binaries to each npm package
 	$(foreach os,$(OSES),$(foreach arch,$(ARCHS), \
 		EXECUTABLE=$(BINARY_NAME)-$(os)-$(arch)$(if $(findstring windows,$(os)),.exe,); \
-		DIRNAME=$(BINARY_NAME)-$(os)-$(arch); \
+		DIRNAME=$(NPM_PKG_PREFIX)-$(os)-$(arch); \
 		mkdir -p ./npm/$$DIRNAME/bin; \
 		cp ./build/$$EXECUTABLE ./npm/$$DIRNAME/bin/; \
 	))
 
-.PHONY: npm-publish
-npm-publish: npm-copy-binaries ## Publish the npm packages
+.PHONY: npm-set-version
+npm-set-version: ## Set version in all npm package.json files
+	@if [ -z "$(NPM_VERSION)" ]; then echo "NPM_VERSION not set (tag the repo first)"; exit 1; fi
 	$(foreach os,$(OSES),$(foreach arch,$(ARCHS), \
-		DIRNAME="$(BINARY_NAME)-$(os)-$(arch)"; \
-		cd npm/$$DIRNAME; \
-		echo '//registry.npmjs.org/:_authToken=$(NPM_TOKEN)' >> .npmrc; \
-		jq '.version = "$(NPM_VERSION)"' package.json > tmp.json && mv tmp.json package.json; \
-		npm publish; \
-		cd ../..; \
+		DIRNAME="$(NPM_PKG_PREFIX)-$(os)-$(arch)"; \
+		jq '.version = "$(NPM_VERSION)"' npm/$$DIRNAME/package.json > npm/$$DIRNAME/tmp.json && mv npm/$$DIRNAME/tmp.json npm/$$DIRNAME/package.json; \
 	))
-	cp README.md LICENSE ./npm/slack-mcp-server/
-	echo '//registry.npmjs.org/:_authToken=$(NPM_TOKEN)' >> ./npm/slack-mcp-server/.npmrc
-	jq '.version = "$(NPM_VERSION)"' ./npm/slack-mcp-server/package.json > tmp.json && mv tmp.json ./npm/slack-mcp-server/package.json; \
-	jq '.optionalDependencies |= with_entries(.value = "$(NPM_VERSION)")' ./npm/slack-mcp-server/package.json > tmp.json && mv tmp.json ./npm/slack-mcp-server/package.json; \
-	cd npm/slack-mcp-server && npm publish
+	jq '.version = "$(NPM_VERSION)"' npm/$(NPM_PKG_PREFIX)/package.json > npm/$(NPM_PKG_PREFIX)/tmp.json && mv npm/$(NPM_PKG_PREFIX)/tmp.json npm/$(NPM_PKG_PREFIX)/package.json
+	jq '.optionalDependencies |= with_entries(.value = "$(NPM_VERSION)")' npm/$(NPM_PKG_PREFIX)/package.json > npm/$(NPM_PKG_PREFIX)/tmp.json && mv npm/$(NPM_PKG_PREFIX)/tmp.json npm/$(NPM_PKG_PREFIX)/package.json
+
+.PHONY: npm-publish
+npm-publish: npm-copy-binaries npm-set-version ## Publish all npm packages (requires NPM_TOKEN or npm login)
+	cp README.md LICENSE ./npm/$(NPM_PKG_PREFIX)/
+	$(foreach os,$(OSES),$(foreach arch,$(ARCHS), \
+		DIRNAME="$(NPM_PKG_PREFIX)-$(os)-$(arch)"; \
+		cd npm/$$DIRNAME && npm publish --access public $(NPM_PUBLISH_FLAGS) && cd ../..; \
+	))
+	cd npm/$(NPM_PKG_PREFIX) && npm publish --access public $(NPM_PUBLISH_FLAGS)
 
 .PHONY: check-network-isolation
 check-network-isolation: ## Verify no rod auto-download calls exist in source

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,72 @@
+# Release Runbook
+
+## Typical Release
+
+```bash
+# 1. Ensure main is clean
+git checkout main && git pull && make build && make test
+
+# 2. Tag the release
+make release TAG=vX.Y.Z
+```
+
+This creates an annotated tag and pushes it. Two GitHub Actions fire:
+- **npm-publish**: cross-compiles, publishes 7 npm packages with provenance
+- **release**: creates GitHub Release with binaries + checksums
+
+## Verify
+
+```bash
+# Watch CI
+gh run list --limit 3
+gh run watch <run-id>
+
+# Check npm
+npm view @aaronsb/slack-mcp version
+
+# Check GitHub Release
+gh release view vX.Y.Z
+```
+
+## First Publish (one-time)
+
+Scoped packages need `--access public` on first publish. The Makefile and CI
+handle this, but the first publish requires npm login + OTP:
+
+```bash
+npm login
+make build-all-platforms
+make npm-copy-binaries
+make npm-set-version NPM_VERSION=1.0.0
+make npm-publish NPM_PUBLISH_FLAGS="--otp=XXXXXX"
+```
+
+After first publish, set up the `NPM_TOKEN` secret in GitHub repo settings
+for CI-based publishing.
+
+## Pre-release
+
+```bash
+make release TAG=v1.1.0-alpha.1
+```
+
+CI auto-detects the pre-release tag and publishes with `--tag alpha` instead
+of `--tag latest`.
+
+## Retagging (if CI fails)
+
+```bash
+git tag -d vX.Y.Z
+git push origin :refs/tags/vX.Y.Z
+# Fix the issue, commit, push
+make release TAG=vX.Y.Z
+```
+
+## Manual Recovery
+
+If `make release` fails partway:
+
+```bash
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push origin vX.Y.Z
+```

--- a/npm/slack-mcp-server-darwin-amd64/package.json
+++ b/npm/slack-mcp-server-darwin-amd64/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "slack-mcp-server-darwin-amd64",
-  "version": "1.1.0",
-  "description": "Model Context Protocol (MCP) server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins",
+  "name": "@aaronsb/slack-mcp-darwin-amd64",
+  "version": "1.2.0",
+  "description": "Platform binary for @aaronsb/slack-mcp (darwin-amd64)",
   "os": [
     "darwin"
   ],
   "cpu": [
     "x64"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aaronsb/slack-mcp.git"
+  },
+  "license": "MIT"
 }

--- a/npm/slack-mcp-server-darwin-arm64/package.json
+++ b/npm/slack-mcp-server-darwin-arm64/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "slack-mcp-server-darwin-arm64",
-  "version": "1.1.0",
-  "description": "Model Context Protocol (MCP) server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins",
+  "name": "@aaronsb/slack-mcp-darwin-arm64",
+  "version": "1.2.0",
+  "description": "Platform binary for @aaronsb/slack-mcp (darwin-arm64)",
   "os": [
     "darwin"
   ],
   "cpu": [
     "arm64"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aaronsb/slack-mcp.git"
+  },
+  "license": "MIT"
 }

--- a/npm/slack-mcp-server-linux-amd64/package.json
+++ b/npm/slack-mcp-server-linux-amd64/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "slack-mcp-server-linux-amd64",
-  "version": "1.1.0",
-  "description": "Model Context Protocol (MCP) server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins",
+  "name": "@aaronsb/slack-mcp-linux-amd64",
+  "version": "1.2.0",
+  "description": "Platform binary for @aaronsb/slack-mcp (linux-amd64)",
   "os": [
     "linux"
   ],
   "cpu": [
     "x64"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aaronsb/slack-mcp.git"
+  },
+  "license": "MIT"
 }

--- a/npm/slack-mcp-server-linux-arm64/package.json
+++ b/npm/slack-mcp-server-linux-arm64/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "slack-mcp-server-linux-arm64",
-  "version": "1.1.0",
-  "description": "Model Context Protocol (MCP) server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins",
+  "name": "@aaronsb/slack-mcp-linux-arm64",
+  "version": "1.2.0",
+  "description": "Platform binary for @aaronsb/slack-mcp (linux-arm64)",
   "os": [
     "linux"
   ],
   "cpu": [
     "arm64"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aaronsb/slack-mcp.git"
+  },
+  "license": "MIT"
 }

--- a/npm/slack-mcp-server-windows-amd64/package.json
+++ b/npm/slack-mcp-server-windows-amd64/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "slack-mcp-server-windows-amd64",
-  "version": "1.1.0",
-  "description": "Model Context Protocol (MCP) server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins",
+  "name": "@aaronsb/slack-mcp-windows-amd64",
+  "version": "1.2.0",
+  "description": "Platform binary for @aaronsb/slack-mcp (windows-amd64)",
   "os": [
     "win32"
   ],
   "cpu": [
     "x64"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aaronsb/slack-mcp.git"
+  },
+  "license": "MIT"
 }

--- a/npm/slack-mcp-server-windows-arm64/package.json
+++ b/npm/slack-mcp-server-windows-arm64/package.json
@@ -1,11 +1,16 @@
 {
-  "name": "slack-mcp-server-windows-arm64",
-  "version": "1.1.0",
-  "description": "Model Context Protocol (MCP) server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins",
+  "name": "@aaronsb/slack-mcp-windows-arm64",
+  "version": "1.2.0",
+  "description": "Platform binary for @aaronsb/slack-mcp (windows-arm64)",
   "os": [
     "win32"
   ],
   "cpu": [
     "arm64"
-  ]
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/aaronsb/slack-mcp.git"
+  },
+  "license": "MIT"
 }

--- a/npm/slack-mcp-server/bin/index.js
+++ b/npm/slack-mcp-server/bin/index.js
@@ -3,19 +3,18 @@
 const childProcess = require('child_process');
 
 const BINARY_MAP = {
-    darwin_x64: {name: 'slack-mcp-server-darwin-amd64', suffix: ''},
-    darwin_arm64: {name: 'slack-mcp-server-darwin-arm64', suffix: ''},
-    linux_x64: {name: 'slack-mcp-server-linux-amd64', suffix: ''},
-    linux_arm64: {name: 'slack-mcp-server-linux-arm64', suffix: ''},
-    win32_x64: {name: 'slack-mcp-server-windows-amd64', suffix: '.exe'},
-    win32_arm64: {name: 'slack-mcp-server-windows-arm64', suffix: '.exe'},
+    darwin_x64: {name: '@aaronsb/slack-mcp-darwin-amd64', bin: 'slack-mcp-darwin-amd64'},
+    darwin_arm64: {name: '@aaronsb/slack-mcp-darwin-arm64', bin: 'slack-mcp-darwin-arm64'},
+    linux_x64: {name: '@aaronsb/slack-mcp-linux-amd64', bin: 'slack-mcp-linux-amd64'},
+    linux_arm64: {name: '@aaronsb/slack-mcp-linux-arm64', bin: 'slack-mcp-linux-arm64'},
+    win32_x64: {name: '@aaronsb/slack-mcp-windows-amd64', bin: 'slack-mcp-windows-amd64.exe'},
+    win32_arm64: {name: '@aaronsb/slack-mcp-windows-arm64', bin: 'slack-mcp-windows-arm64.exe'},
 };
 
-// Resolving will fail if the optionalDependency was not installed or the platform/arch is not supported
 const resolveBinaryPath = () => {
     try {
         const binary = BINARY_MAP[`${process.platform}_${process.arch}`];
-        return require.resolve(`${binary.name}/bin/${binary.name}${binary.suffix}`);
+        return require.resolve(`${binary.name}/bin/${binary.bin}`);
     } catch (e) {
         throw new Error(`Could not resolve binary path for platform/arch: ${process.platform}/${process.arch}`);
     }

--- a/npm/slack-mcp-server/package.json
+++ b/npm/slack-mcp-server/package.json
@@ -1,39 +1,37 @@
 {
-  "name": "slack-mcp-server",
-  "version": "1.1.0",
-  "description": "Model Context Protocol (MCP) server for Slack Workspaces. This integration supports both Stdio and SSE transports, proxy settings and does not require any permissions or bots being created or approved by Workspace admins",
+  "name": "@aaronsb/slack-mcp",
+  "version": "1.2.0",
+  "description": "MCP server for Slack workspaces using session tokens. Automatic browser-based token extraction, stealth reads, channel caching.",
   "main": "bin/index.js",
   "bin": {
-    "slack-mcp-server": "bin/index.js"
+    "slack-mcp": "bin/index.js"
   },
   "optionalDependencies": {
-    "slack-mcp-server-darwin-amd64": "1.1.0",
-    "slack-mcp-server-darwin-arm64": "1.1.0",
-    "slack-mcp-server-linux-amd64": "1.1.0",
-    "slack-mcp-server-linux-arm64": "1.1.0",
-    "slack-mcp-server-windows-amd64": "1.1.0",
-    "slack-mcp-server-windows-arm64": "1.1.0"
+    "@aaronsb/slack-mcp-darwin-amd64": "1.2.0",
+    "@aaronsb/slack-mcp-darwin-arm64": "1.2.0",
+    "@aaronsb/slack-mcp-linux-amd64": "1.2.0",
+    "@aaronsb/slack-mcp-linux-arm64": "1.2.0",
+    "@aaronsb/slack-mcp-windows-amd64": "1.2.0",
+    "@aaronsb/slack-mcp-windows-arm64": "1.2.0"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/korotovsky/slack-mcp-server.git"
+    "url": "git+https://github.com/aaronsb/slack-mcp.git"
   },
   "keywords": [
     "mcp",
     "slack",
-    "slack-api",
-    "model context protocol",
-    "model",
-    "context",
-    "protocol"
+    "model-context-protocol",
+    "ai",
+    "claude"
   ],
   "author": {
-    "name": "Dmitrii Korotovskii",
-    "url": "https://www.linkedin.com/in/korotovsky/"
+    "name": "Aaron Bockelie",
+    "url": "https://github.com/aaronsb"
   },
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/korotovsky/slack-mcp-server/issues"
+    "url": "https://github.com/aaronsb/slack-mcp/issues"
   },
-  "homepage": "https://github.com/korotovsky/slack-mcp-server#readme"
+  "homepage": "https://github.com/aaronsb/slack-mcp#readme"
 }


### PR DESCRIPTION
## Summary

- **CI workflow**: build, test, `check-network-isolation` on push/PR
- **npm-publish workflow**: tag-triggered, cross-compiles all 6 platforms, publishes 7 npm packages with `--provenance`
- **release workflow**: tag-triggered GitHub Release with binaries + checksums
- **Package rename**: `slack-mcp-server` → `@aaronsb/slack-mcp` (scoped)
- **Release runbook** at `docs/release-runbook.md`

First publish completed: `@aaronsb/slack-mcp@1.2.0` + 6 platform binaries on npm.

## Next steps

- Add `NPM_TOKEN` secret to repo settings for CI-based publishing
- Future releases: `make release TAG=vX.Y.Z` triggers everything automatically

## Test plan

- [x] First manual publish to npm succeeded (all 7 packages)
- [ ] CI workflow runs on this PR (will verify)
- [ ] Tag-triggered npm-publish (after NPM_TOKEN secret is configured)