### PR TITLE
Add mcpb bundling to release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,13 +19,27 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Install mcpb CLI
+        run: npm install -g @anthropic-ai/mcpb
+
+      - name: Set version in mcpb manifest
+        run: |
+          VERSION=$(git describe --tags --always | sed 's/^v//' | cut -d- -f1)
+          jq --arg v "$VERSION" '.version = $v' mcpb/manifest.json > mcpb/tmp.json && mv mcpb/tmp.json mcpb/manifest.json
+
       - name: Build all platforms
         run: make build-all-platforms
 
+      - name: Build mcpb bundles
+        run: make mcpb-all
+
       - name: Generate checksums
         run: |
-          cd build
-          sha256sum slack-mcp-* > checksums.txt
+          sha256sum build/slack-mcp-* slack-mcp-*.mcpb > checksums.txt
           cat checksums.txt
 
       - name: Create release
@@ -35,4 +49,4 @@ jobs:
           TAG="${GITHUB_REF#refs/tags/}"
           gh release view "$TAG" 2>/dev/null || \
             gh release create "$TAG" --title "$TAG" --generate-notes
-          gh release upload "$TAG" build/slack-mcp-* build/checksums.txt --clobber
+          gh release upload "$TAG" build/slack-mcp-* slack-mcp-*.mcpb checksums.txt --clobber

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,7 @@ CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),./build/$(BINARY_N
 CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),./npm/$(NPM_PKG_PREFIX)-$(os)-$(arch)/bin/))
 CLEAN_TARGETS += ./npm/$(NPM_PKG_PREFIX)/.npmrc ./npm/$(NPM_PKG_PREFIX)/LICENSE ./npm/$(NPM_PKG_PREFIX)/README.md
 CLEAN_TARGETS += $(foreach os,$(OSES),$(foreach arch,$(ARCHS),./npm/$(NPM_PKG_PREFIX)-$(os)-$(arch)/.npmrc))
+CLEAN_TARGETS += mcpb/bin $(BINARY_NAME)-*.mcpb
 
 # The help will print out all targets with their descriptions organized bellow their categories. The categories are represented by `##@` and the target descriptions by `##`.
 # The awk commands is responsible to read the entire set of makefiles included in this invocation, looking for lines of the file as xyz: ## something, and then pretty-format the target and help. Then, if there's a line with ##@ something, that gets pretty-printed as a category.
@@ -103,6 +104,30 @@ format: ## Format the code
 .PHONY: tidy
 tidy: ## Tidy up the go modules
 	go mod tidy
+
+MCPB_PLATFORMS = darwin-arm64 darwin-x64 linux-arm64 linux-x64 windows-x64
+
+# Map mcpb platform names to our build artifact names
+# mcpb: darwin-arm64 → build: slack-mcp-darwin-arm64
+mcpb_to_binary = $(BINARY_NAME)-$(subst x64,amd64,$(subst windows,windows,$(1)))$(if $(findstring windows,$(1)),.exe,)
+
+.PHONY: mcpb
+mcpb: ## Build .mcpb for a single platform. Usage: make mcpb PLATFORM=linux-x64
+	@if [ -z "$(PLATFORM)" ]; then echo "Usage: make mcpb PLATFORM=linux-x64"; exit 1; fi
+	@echo "Building mcpb for $(PLATFORM)..."
+	rm -rf mcpb/bin
+	mkdir -p mcpb/bin
+	cp ./build/$(call mcpb_to_binary,$(PLATFORM)) mcpb/bin/$(BINARY_NAME)$(if $(findstring windows,$(PLATFORM)),.exe,)
+	mcpb pack mcpb $(BINARY_NAME)-$(PLATFORM).mcpb
+	@echo "Built: $(BINARY_NAME)-$(PLATFORM).mcpb ($$(du -h $(BINARY_NAME)-$(PLATFORM).mcpb | cut -f1))"
+
+.PHONY: mcpb-all
+mcpb-all: build-all-platforms ## Build .mcpb for all platforms
+	@for plat in $(MCPB_PLATFORMS); do \
+		echo ""; \
+		echo "=== $$plat ==="; \
+		$(MAKE) mcpb PLATFORM=$$plat; \
+	done
 
 .PHONY: release
 release: ## Create release tag. Usage: make tag TAG=v1.2.3

--- a/mcpb/.mcpbignore
+++ b/mcpb/.mcpbignore
@@ -1,0 +1,15 @@
+# Exclude everything except the binary and manifest
+.github/
+.claude/
+docs/
+cmd/
+pkg/
+npm/
+build/
+*.go
+*.md
+*.sum
+*.mod
+Makefile
+LICENSE
+CREDITS.md

--- a/mcpb/manifest.json
+++ b/mcpb/manifest.json
@@ -1,0 +1,106 @@
+{
+  "manifest_version": "0.3",
+  "name": "slack-mcp",
+  "display_name": "Slack MCP",
+  "version": "1.2.0",
+  "description": "MCP server for Slack workspaces using session tokens. Automatic browser-based token extraction, stealth reads, channel caching.",
+  "author": {
+    "name": "aaronsb",
+    "url": "https://github.com/aaronsb"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/aaronsb/slack-mcp.git"
+  },
+  "homepage": "https://github.com/aaronsb/slack-mcp#readme",
+  "support": "https://github.com/aaronsb/slack-mcp/issues",
+  "license": "MIT",
+  "keywords": [
+    "slack",
+    "mcp",
+    "model-context-protocol",
+    "ai",
+    "claude"
+  ],
+  "server": {
+    "type": "binary",
+    "entry_point": "bin/slack-mcp",
+    "mcp_config": {
+      "command": "${__dirname}/bin/slack-mcp",
+      "args": [],
+      "env": {
+        "SLACK_XOXC_TOKEN": "${user_config.xoxc_token}",
+        "SLACK_XOXD_TOKEN": "${user_config.xoxd_token}"
+      }
+    }
+  },
+  "tools": [
+    {
+      "name": "check-unreads",
+      "description": "Unread messages across DMs, channels, and mentions"
+    },
+    {
+      "name": "catch-up",
+      "description": "Recent channel activity with time filtering"
+    },
+    {
+      "name": "list-channels",
+      "description": "Browse available channels and membership"
+    },
+    {
+      "name": "check-mentions",
+      "description": "Your @-mentions grouped by urgency"
+    },
+    {
+      "name": "search",
+      "description": "Find messages using full Slack query syntax"
+    },
+    {
+      "name": "get-context",
+      "description": "Thread history and conversation context"
+    },
+    {
+      "name": "check-timing",
+      "description": "Conversation pacing analysis"
+    },
+    {
+      "name": "send-message",
+      "description": "Post to channel, DM, or thread"
+    },
+    {
+      "name": "mark-read",
+      "description": "Mark conversations as read"
+    },
+    {
+      "name": "react",
+      "description": "Add or remove emoji reactions"
+    },
+    {
+      "name": "auth-setup",
+      "description": "Browser-automated Slack token extraction"
+    }
+  ],
+  "user_config": {
+    "xoxc_token": {
+      "type": "string",
+      "title": "Slack xoxc Token",
+      "description": "Session token from Slack. Run the auth-setup tool to extract automatically, or leave blank to use the built-in setup flow.",
+      "sensitive": true,
+      "required": false
+    },
+    "xoxd_token": {
+      "type": "string",
+      "title": "Slack xoxd Cookie",
+      "description": "Session cookie from Slack. Run the auth-setup tool to extract automatically, or leave blank to use the built-in setup flow.",
+      "sensitive": true,
+      "required": false
+    }
+  },
+  "compatibility": {
+    "platforms": [
+      "darwin",
+      "win32",
+      "linux"
+    ]
+  }
+}


### PR DESCRIPTION
## Summary

- `mcpb/manifest.json` — server metadata, tools, user config (tokens optional since auth-setup exists)
- `mcpb/.mcpbignore` — excludes source, dev artifacts from bundles
- Makefile: `make mcpb PLATFORM=linux-x64`, `make mcpb-all` (5 platforms)
- `release.yml` updated: installs mcpb CLI, builds all bundles, attaches to GitHub Release alongside raw binaries
- Version in manifest synced from git tag at build time

On tag push, the release now produces:
- 6 raw binaries + checksums
- 5 `.mcpb` bundles (darwin-arm64, darwin-x64, linux-arm64, linux-x64, windows-x64)

Registry publishing is a separate manual step requiring auth.

## Test plan

- [x] `make mcpb PLATFORM=linux-x64` dry-run mapping verified
- [x] Platform name mapping correct (x64→amd64, windows→.exe)
- [ ] Full mcpb-all build (requires mcpb CLI — tested in CI)
- [ ] Release workflow (triggered on next tag)