### PR TITLE
fix: retrieve full content for standalone messages and search results

### DIFF
--- a/pkg/features/find_discussion_official.go
+++ b/pkg/features/find_discussion_official.go
@@ -123,7 +123,12 @@ func searchUsingOfficialAPI(ctx context.Context, p *provider.ApiProvider, query 
 	if len(discussions) > 0 {
 		result.NextActions = []string{}
 
-		// Primary action: catch up on channels with found content
+		// Suggest get-context for the first result to get full message content
+		first := discussions[0]
+		result.NextActions = append(result.NextActions,
+			fmt.Sprintf("Full message: get-context channel='%s' messageTs='%s'", first["channel"], first["timestamp"]))
+
+		// Also suggest catch-up on channels with found content
 		channelsSeen := map[string]bool{}
 		for _, d := range discussions {
 			ch := d["channel"].(string)
@@ -134,7 +139,7 @@ func searchUsingOfficialAPI(ctx context.Context, p *provider.ApiProvider, query 
 			}
 		}
 
-		result.Guidance = fmt.Sprintf("Found %d discussions about '%s'", len(discussions), query)
+		result.Guidance = fmt.Sprintf("Found %d discussions about '%s'. Use get-context with a message timestamp to retrieve full content.", len(discussions), query)
 	} else {
 		result.Guidance = "No results found. Try different search terms or browse channels."
 		result.NextActions = []string{

--- a/pkg/features/format.go
+++ b/pkg/features/format.go
@@ -473,7 +473,7 @@ func formatSearch(result *FeatureResult) string {
 	for _, msg := range discussions {
 		channel := str(msg, "channel")
 		user := str(msg, "user")
-		text := truncate(str(msg, "text"), 120)
+		text := truncate(str(msg, "text"), 500)
 		ts := str(msg, "timestamp")
 		msgType := str(msg, "type")
 
@@ -482,9 +482,9 @@ func formatSearch(result *FeatureResult) string {
 			threadTag = " [thread]"
 		}
 
-		b.WriteString(fmt.Sprintf("#%s | %s | %s%s\n  %s\n", channel, user, ts, threadTag, text))
+		b.WriteString(fmt.Sprintf("#%s | %s | %s%s\n%s\n", channel, user, ts, threadTag, text))
 		if link := str(msg, "permalink"); link != "" {
-			b.WriteString(fmt.Sprintf("  %s\n", link))
+			b.WriteString(fmt.Sprintf("%s\n", link))
 		}
 		b.WriteString("\n")
 	}

--- a/pkg/features/get_context.go
+++ b/pkg/features/get_context.go
@@ -21,7 +21,7 @@ var GetContext = &Feature{
 			},
 			"messageTs": map[string]interface{}{
 				"type":        "string",
-				"description": "Message timestamp to get context around (optional - if omitted, gets recent messages)",
+				"description": "Message timestamp to retrieve. Returns full content for standalone messages, or full thread for threaded messages. If omitted, gets recent channel messages.",
 			},
 			"count": map[string]interface{}{
 				"type":        "number",
@@ -91,12 +91,16 @@ func getContextHandler(ctx context.Context, params map[string]interface{}) (*Fea
 			Limit:     count,
 		})
 		if threadErr == nil && len(threadMsgs) > 1 {
+			// Actual thread with replies
 			isThread = true
+			messages = threadMsgs
+		} else if threadErr == nil && len(threadMsgs) == 1 {
+			// Standalone message (no replies) — return it directly
 			messages = threadMsgs
 		}
 	}
 
-	// Fall back to channel history
+	// Fall back to channel history (only if no messages found above)
 	if len(messages) == 0 {
 		if messageTs != "" {
 			// Get messages around the specified timestamp

--- a/pkg/setup/cookie_extract.go
+++ b/pkg/setup/cookie_extract.go
@@ -10,8 +10,8 @@ import (
 	"os"
 	"path/filepath"
 
-	_ "modernc.org/sqlite"
 	"golang.org/x/crypto/pbkdf2"
+	_ "modernc.org/sqlite"
 )
 
 // ExtractSlackDCookie reads the "d" cookie directly from Chrome's encrypted


### PR DESCRIPTION
## Summary

- **get-context**: When `messageTs` points to a standalone message (no thread replies), now returns the message directly instead of falling back to surrounding channel history
- **search**: Increased preview from 120 to 500 characters; removed misleading indentation
- **search guidance**: Results now suggest `get-context` with timestamp as first next action, establishing a scan-then-drill workflow for full content retrieval

## Test plan

- [ ] `search` for a long message — verify preview shows up to 500 chars with `...` truncation
- [ ] `get-context` with `messageTs` of a standalone message — verify full message content returned (not surrounding channel history)  
- [ ] `get-context` with `messageTs` of a threaded message — verify thread behavior unchanged
- [ ] `get-context` without `messageTs` — verify recent messages behavior unchanged

Closes #18