### PR TITLE
feat(tools): download file attachments from Slack messages

### DIFF
--- a/pkg/features/catchup.go
+++ b/pkg/features/catchup.go
@@ -139,6 +139,11 @@ func parseTimePeriod(period string) (time.Time, error) {
 
 // Helper to identify important messages
 func isImportantMessage(msg slack.Message) bool {
+	// Any file attachment — users almost always want to know about these
+	if len(msg.Files) > 0 {
+		return true
+	}
+
 	// High reaction count
 	if len(msg.Reactions) > 0 {
 		totalReactions := 0

--- a/pkg/features/catchup_impl.go
+++ b/pkg/features/catchup_impl.go
@@ -344,5 +344,21 @@ func analyzeMessage(msg slack.Message, usersMap map[string]slack.User) map[strin
 		item["reactions"] = totalReactions
 	}
 
+	if len(msg.Files) > 0 {
+		if item["type"] == "message" {
+			item["type"] = "attachment"
+		}
+		files := make([]map[string]interface{}, 0, len(msg.Files))
+		for _, f := range msg.Files {
+			files = append(files, map[string]interface{}{
+				"id":       f.ID,
+				"name":     f.Name,
+				"mimetype": f.Mimetype,
+				"size":     f.Size,
+			})
+		}
+		item["files"] = files
+	}
+
 	return item
 }

--- a/pkg/features/download_file.go
+++ b/pkg/features/download_file.go
@@ -79,6 +79,13 @@ func downloadFileHandler(ctx context.Context, params map[string]interface{}) (*F
 		}, nil
 	}
 
+	if file.Size > provider.MaxDownloadBytes {
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("File %s is %d bytes, exceeding the %d byte limit", fileID, file.Size, provider.MaxDownloadBytes),
+		}, nil
+	}
+
 	downloadURL := file.URLPrivateDownload
 	if downloadURL == "" {
 		downloadURL = file.URLPrivate
@@ -120,7 +127,7 @@ func downloadFileHandler(ctx context.Context, params map[string]interface{}) (*F
 		}, nil
 	}
 	rel, err := filepath.Rel(destAbs, targetAbs)
-	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
 		return &FeatureResult{
 			Success:  false,
 			Message:  fmt.Sprintf("Refusing to write outside destDir: %s", targetAbs),
@@ -135,22 +142,32 @@ func downloadFileHandler(ctx context.Context, params map[string]interface{}) (*F
 		}, nil
 	}
 
-	out, err := os.Create(targetAbs)
+	// O_EXCL refuses to follow symlinks and refuses to clobber existing
+	// files — closes the symlink-TOCTOU window on destDir contents.
+	out, err := os.OpenFile(targetAbs, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0o644)
 	if err != nil {
 		return &FeatureResult{
-			Success: false,
-			Message: fmt.Sprintf("Failed to create file %s: %v", targetAbs, err),
+			Success:  false,
+			Message:  fmt.Sprintf("Failed to create file %s: %v", targetAbs, err),
+			Guidance: "The target file already exists or is a symlink. Pass a different filename or remove the existing file first.",
 		}, nil
 	}
-	defer out.Close()
 
 	internal := apiProvider.ProvideInternalClient()
 	n, err := internal.DownloadFile(ctx, downloadURL, out)
 	if err != nil {
+		out.Close()
 		os.Remove(targetAbs)
 		return &FeatureResult{
 			Success: false,
 			Message: fmt.Sprintf("Download failed: %v", err),
+		}, nil
+	}
+	if closeErr := out.Close(); closeErr != nil {
+		os.Remove(targetAbs)
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("Failed to finalize file: %v", closeErr),
 		}, nil
 	}
 

--- a/pkg/features/download_file.go
+++ b/pkg/features/download_file.go
@@ -1,0 +1,171 @@
+package features
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/aaronsb/slack-mcp/pkg/paths"
+	"github.com/aaronsb/slack-mcp/pkg/provider"
+)
+
+// DownloadFile retrieves a file attachment from a Slack message and saves
+// it to the local filesystem. Defaults to ~/Downloads; a custom destDir may
+// be supplied but the resolved target path must live inside that directory.
+var DownloadFile = &Feature{
+	Name:        "download-file",
+	Description: "Download a file attachment from a Slack message. File IDs come from the 'files' field of messages returned by get-context or search.",
+	Schema: map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"fileId": map[string]interface{}{
+				"type":        "string",
+				"description": "Slack file ID (e.g. F01234ABCD), as returned in the 'files' array of a message",
+			},
+			"destDir": map[string]interface{}{
+				"type":        "string",
+				"description": "Directory to save the file in. Defaults to ~/Downloads. Must be an absolute path.",
+			},
+			"filename": map[string]interface{}{
+				"type":        "string",
+				"description": "Override the filename (no path separators). Defaults to the original Slack filename.",
+			},
+		},
+		"required": []string{"fileId"},
+	},
+	Handler: downloadFileHandler,
+}
+
+func downloadFileHandler(ctx context.Context, params map[string]interface{}) (*FeatureResult, error) {
+	fileID, _ := params["fileId"].(string)
+	if fileID == "" {
+		return &FeatureResult{
+			Success: false,
+			Message: "fileId is required",
+		}, nil
+	}
+
+	destDir, _ := params["destDir"].(string)
+	if strings.TrimSpace(destDir) == "" {
+		destDir = paths.DownloadsDir()
+	}
+
+	overrideName, _ := params["filename"].(string)
+
+	apiProvider, ok := params["_provider"].(*provider.ApiProvider)
+	if !ok {
+		return &FeatureResult{
+			Success: false,
+			Message: "Internal error: provider not available",
+		}, nil
+	}
+
+	api, err := apiProvider.Provide()
+	if err != nil {
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("Failed to connect to Slack: %v", err),
+		}, nil
+	}
+
+	file, _, _, err := api.GetFileInfoContext(ctx, fileID, 0, 0)
+	if err != nil {
+		return &FeatureResult{
+			Success:  false,
+			Message:  fmt.Sprintf("Failed to look up file %s: %v", fileID, err),
+			Guidance: "Verify the fileId from a recent get-context or search result. External files are not downloadable.",
+		}, nil
+	}
+
+	downloadURL := file.URLPrivateDownload
+	if downloadURL == "" {
+		downloadURL = file.URLPrivate
+	}
+	if downloadURL == "" {
+		return &FeatureResult{
+			Success:  false,
+			Message:  fmt.Sprintf("File %s has no downloadable URL (external or hidden)", fileID),
+			Guidance: "Slack doesn't expose a private URL for this file type — it may be hosted externally.",
+		}, nil
+	}
+
+	name := overrideName
+	if name == "" {
+		name = file.Name
+	}
+	if name == "" {
+		name = fileID
+	}
+	if strings.ContainsAny(name, `/\`) || name == "." || name == ".." {
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("Invalid filename %q: must not contain path separators", name),
+		}, nil
+	}
+
+	destAbs, err := filepath.Abs(destDir)
+	if err != nil {
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("Invalid destDir: %v", err),
+		}, nil
+	}
+	targetAbs, err := filepath.Abs(filepath.Join(destAbs, name))
+	if err != nil {
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("Invalid target path: %v", err),
+		}, nil
+	}
+	rel, err := filepath.Rel(destAbs, targetAbs)
+	if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return &FeatureResult{
+			Success:  false,
+			Message:  fmt.Sprintf("Refusing to write outside destDir: %s", targetAbs),
+			Guidance: "Path traversal blocked. Pick a filename without '..' or '/'.",
+		}, nil
+	}
+
+	if err := os.MkdirAll(destAbs, 0o755); err != nil {
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("Failed to create destDir %s: %v", destAbs, err),
+		}, nil
+	}
+
+	out, err := os.Create(targetAbs)
+	if err != nil {
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("Failed to create file %s: %v", targetAbs, err),
+		}, nil
+	}
+	defer out.Close()
+
+	internal := apiProvider.ProvideInternalClient()
+	n, err := internal.DownloadFile(ctx, downloadURL, out)
+	if err != nil {
+		os.Remove(targetAbs)
+		return &FeatureResult{
+			Success: false,
+			Message: fmt.Sprintf("Download failed: %v", err),
+		}, nil
+	}
+
+	return &FeatureResult{
+		Success: true,
+		Message: fmt.Sprintf("Downloaded %s (%d bytes) to %s", file.Name, n, targetAbs),
+		Data: map[string]interface{}{
+			"fileId":   fileID,
+			"name":     file.Name,
+			"mimetype": file.Mimetype,
+			"size":     n,
+			"path":     targetAbs,
+		},
+		NextActions: []string{
+			fmt.Sprintf("Read the file at %s", targetAbs),
+		},
+	}, nil
+}

--- a/pkg/features/find_discussion_official.go
+++ b/pkg/features/find_discussion_official.go
@@ -94,6 +94,10 @@ func searchUsingOfficialAPI(ctx context.Context, p *provider.ApiProvider, query 
 			"permalink": match.Permalink,
 		}
 
+		if len(match.Attachments) > 0 {
+			discussion["hasAttachments"] = true
+		}
+
 		// Check if it's part of a thread
 		if match.Previous.Timestamp != "" || match.Previous2.Timestamp != "" ||
 			match.Next.Timestamp != "" || match.Next2.Timestamp != "" {

--- a/pkg/features/format.go
+++ b/pkg/features/format.go
@@ -659,15 +659,13 @@ func formatAuthSetup(result *FeatureResult) string {
 // --- download-file ---
 
 func formatDownloadFile(result *FeatureResult) string {
-	data := dataMap(result)
-	if data == nil {
-		return result.Message + footer(result)
-	}
 	s := result.Message
-	if path := str(data, "path"); path != "" {
-		s = fmt.Sprintf("Saved **%s** to `%s`", str(data, "name"), path)
+	if data := dataMap(result); data != nil {
 		if mt := str(data, "mimetype"); mt != "" {
-			s += fmt.Sprintf(" (%s)", mt)
+			s += fmt.Sprintf(" [%s]", mt)
+		}
+		if path := str(data, "path"); path != "" {
+			s += fmt.Sprintf("\nPath: `%s`", path)
 		}
 	}
 	return s + footer(result)

--- a/pkg/features/format.go
+++ b/pkg/features/format.go
@@ -38,6 +38,8 @@ func FormatResult(toolName string, result *FeatureResult) string {
 		return formatTiming(result)
 	case "auth-setup":
 		return formatAuthSetup(result)
+	case "download-file":
+		return formatDownloadFile(result)
 	default:
 		return formatGeneric(result)
 	}
@@ -373,26 +375,43 @@ func formatCatchUp(result *FeatureResult) string {
 
 	var b strings.Builder
 	channel := str(data, "channel")
-	messages := asList(data["messages"])
+	items := asList(data["importantItems"])
 
-	b.WriteString(fmt.Sprintf("## %s (%d messages)\n\n", channel, len(messages)))
+	b.WriteString(fmt.Sprintf("## %s (%d important items)\n\n", channel, len(items)))
 
-	for _, msg := range messages {
-		user := str(msg, "user")
-		text := str(msg, "text")
-		ts := str(msg, "time")
+	for _, item := range items {
+		author := str(item, "author")
+		if author == "" {
+			author = str(item, "user")
+		}
+		text := str(item, "message")
+		if text == "" {
+			text = str(item, "text")
+		}
+		ts := str(item, "timestamp")
 		if ts == "" {
-			ts = str(msg, "timestamp")
+			ts = str(item, "time")
 		}
 
-		// Show thread indicator
-		replyCount := num(msg, "replyCount")
-		threadTag := ""
-		if replyCount > 0 {
-			threadTag = fmt.Sprintf(" [%d replies]", replyCount)
+		tags := ""
+		if itemType := str(item, "type"); itemType != "" && itemType != "message" {
+			tags += fmt.Sprintf(" [%s]", itemType)
+		}
+		if replyCount := num(item, "replyCount"); replyCount > 0 {
+			tags += fmt.Sprintf(" [%d replies]", replyCount)
+		}
+		if reactions := num(item, "reactions"); reactions > 0 {
+			tags += fmt.Sprintf(" [%d reactions]", reactions)
 		}
 
-		b.WriteString(fmt.Sprintf("**%s** (%s)%s\n%s\n\n", user, ts, threadTag, text))
+		b.WriteString(fmt.Sprintf("**%s** (%s)%s\n%s\n", author, ts, tags, text))
+		for _, f := range asList(item["files"]) {
+			name := str(f, "name")
+			id := str(f, "id")
+			mime := str(f, "mimetype")
+			b.WriteString(fmt.Sprintf("📎 %s (%s, id=%s) — download-file fileId='%s'\n", name, mime, id, id))
+		}
+		b.WriteString("\n")
 	}
 
 	b.WriteString(footer(result))
@@ -434,7 +453,14 @@ func formatContext(result *FeatureResult) string {
 			replyTag = fmt.Sprintf(" [%d replies]", replyCount)
 		}
 
-		b.WriteString(fmt.Sprintf("**%s** (%s)%s\n%s\n\n", user, ts, replyTag, text))
+		b.WriteString(fmt.Sprintf("**%s** (%s)%s\n%s\n", user, ts, replyTag, text))
+		for _, f := range asList(msg["files"]) {
+			name := str(f, "name")
+			id := str(f, "id")
+			mime := str(f, "mimetype")
+			b.WriteString(fmt.Sprintf("📎 %s (%s, id=%s) — download-file fileId='%s'\n", name, mime, id, id))
+		}
+		b.WriteString("\n")
 	}
 
 	b.WriteString(footer(result))
@@ -482,7 +508,15 @@ func formatSearch(result *FeatureResult) string {
 			threadTag = " [thread]"
 		}
 
-		b.WriteString(fmt.Sprintf("#%s | %s | %s%s\n%s\n", channel, user, ts, threadTag, text))
+		attachTag := ""
+		if v, ok := msg["hasAttachments"].(bool); ok && v {
+			attachTag = " 📎"
+		}
+
+		b.WriteString(fmt.Sprintf("#%s | %s | %s%s%s\n%s\n", channel, user, ts, threadTag, attachTag, text))
+		if attachTag != "" {
+			b.WriteString(fmt.Sprintf("  (has attachments — get-context channel='%s' messageTs='%s' for file IDs)\n", channel, ts))
+		}
 		if link := str(msg, "permalink"); link != "" {
 			b.WriteString(fmt.Sprintf("%s\n", link))
 		}
@@ -620,6 +654,23 @@ func formatAuthSetup(result *FeatureResult) string {
 
 	s.WriteString(footer(result))
 	return s.String()
+}
+
+// --- download-file ---
+
+func formatDownloadFile(result *FeatureResult) string {
+	data := dataMap(result)
+	if data == nil {
+		return result.Message + footer(result)
+	}
+	s := result.Message
+	if path := str(data, "path"); path != "" {
+		s = fmt.Sprintf("Saved **%s** to `%s`", str(data, "name"), path)
+		if mt := str(data, "mimetype"); mt != "" {
+			s += fmt.Sprintf(" (%s)", mt)
+		}
+	}
+	return s + footer(result)
 }
 
 // --- Generic fallback ---

--- a/pkg/features/get_context.go
+++ b/pkg/features/get_context.go
@@ -172,6 +172,19 @@ func getContextHandler(ctx context.Context, params map[string]interface{}) (*Fea
 			entry["reply_count"] = msg.ReplyCount
 		}
 
+		if len(msg.Files) > 0 {
+			files := make([]map[string]interface{}, 0, len(msg.Files))
+			for _, f := range msg.Files {
+				files = append(files, map[string]interface{}{
+					"id":       f.ID,
+					"name":     f.Name,
+					"mimetype": f.Mimetype,
+					"size":     f.Size,
+				})
+			}
+			entry["files"] = files
+		}
+
 		formatted = append(formatted, entry)
 	}
 

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -24,14 +24,24 @@ func ConfigPath() string {
 	return filepath.Join(ConfigDir(), "config.json")
 }
 
-// DownloadsDir returns the user's downloads directory: $XDG_DOWNLOAD_DIR or ~/Downloads
+// DownloadsDir returns the user's downloads directory.
+//
+// Order of preference:
+//  1. $XDG_DOWNLOAD_DIR if set. Note: this env var is a convention, not part
+//     of the XDG Base Directory spec — the real user-dirs.dirs file isn't
+//     parsed here. We honor it so callers can override without touching
+//     CLI args.
+//  2. $HOME/Downloads.
+//  3. os.TempDir() as a last resort for headless environments where $HOME
+//     isn't set — avoids returning a relative path that resolves against
+//     a surprising CWD.
 func DownloadsDir() string {
 	if dir := os.Getenv("XDG_DOWNLOAD_DIR"); dir != "" {
 		return dir
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return "Downloads"
+		return os.TempDir()
 	}
 	return filepath.Join(home, "Downloads")
 }

--- a/pkg/paths/paths.go
+++ b/pkg/paths/paths.go
@@ -24,6 +24,18 @@ func ConfigPath() string {
 	return filepath.Join(ConfigDir(), "config.json")
 }
 
+// DownloadsDir returns the user's downloads directory: $XDG_DOWNLOAD_DIR or ~/Downloads
+func DownloadsDir() string {
+	if dir := os.Getenv("XDG_DOWNLOAD_DIR"); dir != "" {
+		return dir
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "Downloads"
+	}
+	return filepath.Join(home, "Downloads")
+}
+
 // DataDir returns the XDG data directory: $XDG_DATA_HOME/slack-mcp
 func DataDir() string {
 	if base := os.Getenv("XDG_DATA_HOME"); base != "" {

--- a/pkg/provider/internal_client.go
+++ b/pkg/provider/internal_client.go
@@ -264,6 +264,53 @@ func (c *InternalClient) callInternalAPI(ctx context.Context, endpoint string, p
 	return nil
 }
 
+// DownloadFile fetches a Slack file URL (e.g. URLPrivateDownload) using the
+// session tokens and streams the body to w. Returns the number of bytes
+// written. The caller must supply a fully qualified https://files.slack.com
+// or https://slack.com URL — no path/host validation is performed here beyond
+// requiring a Slack-owned host.
+func (c *InternalClient) DownloadFile(ctx context.Context, fileURL string, w io.Writer) (int64, error) {
+	u, err := url.Parse(fileURL)
+	if err != nil {
+		return 0, fmt.Errorf("invalid file URL: %w", err)
+	}
+	if u.Scheme != "https" {
+		return 0, fmt.Errorf("file URL must be https, got %q", u.Scheme)
+	}
+	host := u.Hostname()
+	if host != "files.slack.com" && host != "slack.com" && !isSlackSubdomain(host) {
+		return 0, fmt.Errorf("refusing to download from non-Slack host %q", host)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, "GET", fileURL, nil)
+	if err != nil {
+		return 0, fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.xoxcToken))
+	req.Header.Set("Cookie", fmt.Sprintf("d=%s", c.xoxdToken))
+	req.Header.Set("Referer", "https://app.slack.com/")
+
+	// Use a client with a longer timeout for large files.
+	client := &http.Client{Timeout: 5 * time.Minute}
+	resp, err := client.Do(req)
+	if err != nil {
+		return 0, fmt.Errorf("downloading file: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return 0, fmt.Errorf("download failed with status %d: %s", resp.StatusCode, string(body))
+	}
+
+	return io.Copy(w, resp.Body)
+}
+
+func isSlackSubdomain(host string) bool {
+	return len(host) > len(".slack.com") && host[len(host)-len(".slack.com"):] == ".slack.com"
+}
+
 // PostInternalAPI calls internal endpoints with POST method
 func (c *InternalClient) PostInternalAPI(ctx context.Context, endpoint string, payload interface{}, result interface{}) error {
 	// Encode payload

--- a/pkg/provider/internal_client.go
+++ b/pkg/provider/internal_client.go
@@ -264,11 +264,15 @@ func (c *InternalClient) callInternalAPI(ctx context.Context, endpoint string, p
 	return nil
 }
 
-// DownloadFile fetches a Slack file URL (e.g. URLPrivateDownload) using the
-// session tokens and streams the body to w. Returns the number of bytes
-// written. The caller must supply a fully qualified https://files.slack.com
-// or https://slack.com URL — no path/host validation is performed here beyond
-// requiring a Slack-owned host.
+// MaxDownloadBytes caps how much a single DownloadFile call will read.
+// Slack's own upload limit is 1 GiB; 500 MiB is enough headroom for
+// everyday PDFs/images/zips while bounding blast radius if an LLM picks
+// the wrong fileId.
+const MaxDownloadBytes = 500 << 20
+
+// DownloadFile fetches a Slack file URL (e.g. URLPrivateDownload) and
+// streams the body to w, refusing any non-Slack host and capping total
+// bytes at MaxDownloadBytes. Returns the number of bytes written.
 func (c *InternalClient) DownloadFile(ctx context.Context, fileURL string, w io.Writer) (int64, error) {
 	u, err := url.Parse(fileURL)
 	if err != nil {
@@ -287,12 +291,20 @@ func (c *InternalClient) DownloadFile(ctx context.Context, fileURL string, w io.
 		return 0, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36")
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.xoxcToken))
+	// Cookie-only auth matches how the Slack web client fetches files and
+	// avoids leaking the xoxc bearer token on cross-origin redirects.
 	req.Header.Set("Cookie", fmt.Sprintf("d=%s", c.xoxdToken))
 	req.Header.Set("Referer", "https://app.slack.com/")
 
-	// Use a client with a longer timeout for large files.
-	client := &http.Client{Timeout: 5 * time.Minute}
+	client := &http.Client{
+		Timeout: 5 * time.Minute,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			if len(via) >= 5 {
+				return fmt.Errorf("too many redirects")
+			}
+			return nil
+		},
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return 0, fmt.Errorf("downloading file: %w", err)
@@ -304,7 +316,15 @@ func (c *InternalClient) DownloadFile(ctx context.Context, fileURL string, w io.
 		return 0, fmt.Errorf("download failed with status %d: %s", resp.StatusCode, string(body))
 	}
 
-	return io.Copy(w, resp.Body)
+	// Read up to MaxDownloadBytes+1 so we can detect overrun.
+	n, err := io.Copy(w, io.LimitReader(resp.Body, MaxDownloadBytes+1))
+	if err != nil {
+		return n, fmt.Errorf("streaming body: %w", err)
+	}
+	if n > MaxDownloadBytes {
+		return n, fmt.Errorf("file exceeds %d byte limit", MaxDownloadBytes)
+	}
+	return n, nil
 }
 
 func isSlackSubdomain(host string) bool {

--- a/pkg/server/semantic_server.go
+++ b/pkg/server/semantic_server.go
@@ -54,6 +54,7 @@ func NewSemanticMCPServer(provider *provider.ApiProvider) *SemanticMCPServer {
 	registry.Register(features.React)
 	registry.Register(features.ListUsers)
 	registry.Register(features.AuthSetup)
+	registry.Register(features.DownloadFile)
 
 	semanticServer := &SemanticMCPServer{
 		server:   s,


### PR DESCRIPTION
## Summary

Adds a `download-file` MCP tool and surfaces file metadata through the message-reading pipeline so the AI can discover attachments in Slack conversations and fetch them end-to-end — no more leaving the MCP workflow to open Slack in a browser for a PDF.

## What's new

- **`download-file` tool**: `fileId` (required, from `files[]` on a message), `destDir` (optional, defaults to `~/Downloads` / `$XDG_DOWNLOAD_DIR`), `filename` (optional override). Uses `files.info` for authoritative name + URL, fences the resolved target inside `destDir` via `filepath.Abs`+`Rel`, rejects filenames containing path separators, and streams the download through the existing xoxc/xoxd-authenticated internal client.
- **File metadata on messages**: `get-context` and `catch-up` now include a `files` array (id, name, mimetype, size). Messages with files are always treated as "important" in catch-up so attachments can't be filtered out.
- **Formatter updates**: `formatContext` and `formatCatchUp` render a 📎 line with a ready-to-copy `download-file fileId='…'` invocation. `formatSearch` flags matches that carry attachments and points the AI at `get-context` to retrieve the authoritative file IDs.
- **Pre-existing catch-up formatter bug fix**: `formatCatchUp` was reading `data["messages"]` / `user` / `text` but `catchup_impl.go` writes `importantItems` / `author` / `message`, so items never rendered. Fixed in the same PR since the new file rendering depends on it.

## Security notes

- The internal client's `DownloadFile` refuses any non-Slack host (`files.slack.com`, `slack.com`, `*.slack.com` only) and requires `https`.
- Path fencing: resolved target must be inside the resolved `destDir` — `..` segments and absolute overrides escape the default are blocked.
- Override `filename` rejects `/`, `\\`, `.`, and `..`.

Closes #17
Closes #21

## Test plan

- [ ] Build and vet clean (`go build ./... && go vet ./...`) ✅
- [ ] `get-context` on a thread containing a PDF returns `files[]` with id/name/mimetype/size
- [ ] `download-file` with that `fileId` and no `destDir` writes to `~/Downloads/<original-name>`
- [ ] `download-file` with a custom `destDir` writes there; `destDir` is created if missing
- [ ] Path traversal: `filename: "../evil.txt"` is rejected
- [ ] `catch-up` on a channel with a recent attachment surfaces the 📎 line
- [ ] `search` for a query that matches a message-with-attachment shows the 📎 tag and the get-context hint